### PR TITLE
Fix  `on_player_setup_blueprint`: Use `set_blueprint_entity_tag(s)` instead of `set_blueprint_entities`

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -138,27 +138,13 @@ local function on_player_setup_blueprint(event)
   if bp and bp.is_blueprint and bp.is_blueprint_setup() then
     local mapping = event.mapping.get()
     local blueprint_entities = bp.get_blueprint_entities()
-    local found = false
-    if blueprint_entities then
-      for _, bp_entity in pairs(blueprint_entities) do
-        local entity = mapping[bp_entity.entity_number]
-        if entity and entity.train and not entity.train.manual_mode then
-          --Add train tags for automatic mode
-          found = true
-          if not bp_entity.tags then bp_entity.tags = {} end
-          bp_entity.tags.automatic_mode = true
-          bp_entity.tags.length = #entity.train.carriages
-
-        elseif bp_entity.name == "recursive-blueprints-scanner" then
-          found = true
-          bp_entity.control_behavior = nil
-          if entity then
-            bp_entity.tags = AreaScanner.serialize(entity)
-          end
-        end
-      end
-      if found then
-        bp.set_blueprint_entities(blueprint_entities)
+    for index, entity in pairs(mapping) do
+      if entity and entity.train and not entity.train.manual_mode then
+        --Add train tags for automatic mode
+        bp.set_blueprint_entity_tag(index, "automatic_mode", true)
+        bp.set_blueprint_entity_tag(index, "length", #entity.train.carriages)
+      elseif entity.name == "recursive-blueprints-scanner" and entity then
+        bp.set_blueprint_entity_tags(index, AreaScanner.serialize(entity))
       end
     end
   end

--- a/lualib/rb-util.lua
+++ b/lualib/rb-util.lua
@@ -154,9 +154,9 @@ end
 
 function RB_util.on_built_carriage(entity, tags)
   -- Check for automatic mode tag
-  if tags and tags.manual_mode ~= nil and tags.manual_mode == false then
+  if tags and tags.automatic_mode ~= nil and tags.automatic_mode == true then
     -- Wait for the entire train to be built
-    if tags.train_length == #entity.train.carriages then
+    if tags.length == #entity.train.carriages then
       -- Turn on automatic mode
       RB_util.enable_automatic_mode(entity.train)
     end


### PR DESCRIPTION
`set_blueprint_entities` was deleting `event.mapping`, which prevented other mods from storing their tags.